### PR TITLE
Handle dynamic table columns, names or joins

### DIFF
--- a/models/models.go
+++ b/models/models.go
@@ -15,6 +15,9 @@ type JobReq struct {
 	Args     []string `json:"args"`
 	DB       string   `json:"db"`
 
+	// Optional params
+	DynamicParams []string `json:"dynamic_params"`
+
 	ttlDuration time.Duration
 }
 


### PR DESCRIPTION
Trying to handle dynamic table columns, names or joins

SQL Eg:
```sql
-- name: get_profit_entries_by_date
-- raw: 1
SELECT * FROM $1 WHERE user_id = ? AND timestamp > ? and timestamp < ?;
```
Here $1 can be replaced with any table name.

Request Sample:
```curl
curl localhost:6060/tasks/get_profit_entries_by_date/jobs -H "Content-Type: application/json" -X POST --data '{"job_id": "myjob", "args": ["USER1", "2017-12-01", "2017-01-01"], "dynamic_params": ["entries"]}'

{"status":"success","data":{"job_id":"myjob","task_name":"get_profit_entries_by_date","queue":"sqljob_queue","eta":null,"retries":0}}
```