### PR TITLE
ci: fix step order, drop EOL Go 1.21, add concurrency groups, timeouts, upgrade actions to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,16 +11,17 @@ permissions:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: "1.24"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,22 @@ on:
       - master
 
 name: run tests
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  
 jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.24.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
+    timeout-minutes: 20
 
     services:
       redis:
@@ -51,16 +60,16 @@ jobs:
         # volumes:
         #   - mysql_data:/var/lib/mysql
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Install Go
-      if: success()
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
+        
     - name: Install Dependenies
       run:  sudo apt-get update && sudo apt-get install -y --no-install-recommends ca-certificates postgresql-client
-
-    - name: Checkout code
-      uses: actions/checkout@v3
 
     - name: Add postgres tables
       run: PGPASSWORD=testPass psql -U testUser -h localhost -p 5432 -d testDB -c 'CREATE TABLE entries (id BIGSERIAL PRIMARY KEY, amount REAL, user_id VARCHAR(6), entry_date DATE, timestamp TIMESTAMP)';


### PR DESCRIPTION
Was going through the workflows and noticed a few things.

### test.yml

Steps were in the wrong order as `setup-go` and `apt-get install` ran before `checkout`. `setup-go@v4` needs `go.sum` to build its cache key, and that file doesn't exist until the repo is checked out. So the module cache was being skipped silently on every run. Moved checkout to the top to fix it.

- Removed the `if: success()` on what was the first step. First step in a job can't have a prior failure as the guard never did anything.
- `go-version: 1.21.x` → `1.24.x`. Go 1.21 went EOL February 2024.
- `checkout@v3` → `v4`. v3 is deprecated.
- Added a concurrency group so new pushes cancel stale runs on the same branch instead of piling up.
- Added `timeout-minutes: 20`. Without it a hung healthcheck or stuck build just sits there until GitHub's 6-hour limit.
- Added `permissions: contents: read` to scope the token down for a test job.

### release.yml

- `checkout@v3` → `v4`.
- `go-version: "1.21"` → `"1.24"`. Release binaries shouldn't be built with an EOL toolchain.
- Added `timeout-minutes: 20` in case a goreleaser upload stalls.
- Skipped the concurrency group leading to cancelling a release mid-flight would be bad.